### PR TITLE
Ignore the nginx errors if scale down is performed.

### DIFF
--- a/ansible_scripts/roles/custom_scaledown_role/tasks/config_nginx.yml
+++ b/ansible_scripts/roles/custom_scaledown_role/tasks/config_nginx.yml
@@ -2,10 +2,15 @@
 - name: Get the present configmap
   become: true
   shell: kubectl get cm esnginx-sfnginxv1 -o yaml > /tmp/esnginx-sfnginxv1_cm.yaml
+  ignore_errors: True
+  register: kubectl_cmd
+- debug: msg="Kubectl command execution failed. Please remove the node ip {{ exclude_node_ip }} manaully in nginx configmap. For more details please check troubleshooting guide."
+  when: kubectl_cmd.stderr != ""
 - name: Check if the excluding node ip is already present
   become: true
   shell: sed -n "/server {{ exclude_node_ip }}:9200;/p" /tmp/esnginx-sfnginxv1_cm.yaml
   register: check_node_ip
+  when: kubectl_cmd.stderr == ""
 - name: Remove the node ip from configmap
   become: true
   lineinfile:
@@ -13,8 +18,8 @@
     regexp: server {{ exclude_node_ip }}:9200;
     state: absent
     backup: true
-  when: check_node_ip.stdout != ""
+  when: kubectl_cmd.stderr == "" and check_node_ip.stdout != ""
 - name: Apply the update config map
   become: true
   shell: kubectl apply -f /tmp/esnginx-sfnginxv1_cm.yaml
-  when: check_node_ip.stdout != ""
+  when: kubectl_cmd.stderr == "" and check_node_ip.stdout != ""


### PR DESCRIPTION
Since the removal of ip in scale down will not create issue in nginx configuration We can go ahead with the termination and can take this task for future scope of implementation to add retry mechanism.